### PR TITLE
PT-268 JMeter buildpack: specify plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Buildpack to install JMeter to a Cloud Foundry app
 Downloads the following. Details for these are in `parameters.sh`. 
   
 - JMeter
+- Selected JMeter Plugins
 - Java
 - AWS CLI
 
@@ -60,6 +61,17 @@ Once you have set JAVA_HOME, you will be able to run JMeter.
 When using a custom start command, the working directory is set to the `/app/` directory, therefore you can execute JMeter by running `./jmeter/bin/jmeter.sh`.
 
 When SSHing, the working directory is set to the `/home/` directory, therefore you can execute JMeter by running `./app/jmeter/bin/jmeter.sh`.
+
+# JMeter Plugins
+
+The following list of JMeter plugins get installed:
+
+- WebsocketSamplers v1.2.10 - https://jmeter-plugins.org/files/packages/websocket-samplers-1.2.10.zip
+- Custom Thread Groups v2.10 - https://jmeter-plugins.org/files/packages/jpgc-casutg-2.10.zip
+- Random CSV Data Set v0.8 - https://jmeter-plugins.org/files/packages/bzm-random-csv-0.8.zip
+- Dummy Sampler v0.4 - https://jmeter-plugins.org/files/packages/jpgc-dummy-0.4.zip
+- Parameterized Controller  Set Variables Action v0.4 - https://jmeter-plugins.org/files/packages/jpgc-prmctl-0.4.zip
+- Weighted Switch Controller v0.7 - https://jmeter-plugins.org/files/packages/jpgc-wsc-0.7.zip
 
 # Utils
 

--- a/bin/supply
+++ b/bin/supply
@@ -26,10 +26,12 @@ else
     mv "${JMETER_DIR}" "${CACHE_DIR}/${JMETER_DIR}"
 
     # Install JMeter plugins
+    # Plugins jars must be copied to jmeter/lib/ext
     for PLUGIN in "${JMETER_PLUGINS[@]}"; do
         echo "-----> Downloading JMeter plugin: $PLUGIN"
         curl -fsSLO "${JMETER_PLUGINS_BASE_URL}${PLUGIN}"
         echo "-----> Unzipping ${PLUGIN}"
+        # The file structure of all the plugins .zips has /lib/ext so we don't need to specify these.
         unzip -oq "${PLUGIN}" -d "${CACHE_DIR}/${JMETER_DIR}"
     done
 fi

--- a/bin/supply
+++ b/bin/supply
@@ -26,11 +26,11 @@ else
     mv "${JMETER_DIR}" "${CACHE_DIR}/${JMETER_DIR}"
 
     # Install JMeter plugins
-    for PLUGIN in "${JMETER_PLUGINS}"; do
+    for PLUGIN in "${JMETER_PLUGINS[@]}"; do
         echo "-----> Downloading JMeter plugin: $PLUGIN"
         curl -fsSLO "${JMETER_PLUGINS_BASE_URL}${PLUGIN}"
         echo "-----> Unzipping ${PLUGIN}"
-        unzip -oq "${PLUGIN}" -d "${CACHE_DIR}/${JMETER_DIR}/lib/ext"
+        unzip -oq "${PLUGIN}" -d "${CACHE_DIR}/${JMETER_DIR}"
     done
 fi
 

--- a/bin/supply
+++ b/bin/supply
@@ -24,6 +24,14 @@ else
     tar -zxf "${JMETER_ARCHIVE}"
     echo "-----> Moving ${JMETER_DIR} to cache dir"
     mv "${JMETER_DIR}" "${CACHE_DIR}/${JMETER_DIR}"
+
+    # Install JMeter plugins
+    for PLUGIN in "${JMETER_PLUGINS}"; do
+        echo "-----> Downloading JMeter plugin: $PLUGIN"
+        curl -fsSLO "${JMETER_PLUGINS_BASE_URL}${PLUGIN}"
+        echo "-----> Unzipping ${PLUGIN}"
+        unzip -oq "${PLUGIN}" -d "${CACHE_DIR}/${JMETER_DIR}/lib/ext"
+    done
 fi
 
 # Copy JMeter from the cache dir to the build dir

--- a/parameters.sh
+++ b/parameters.sh
@@ -13,8 +13,6 @@ JMETER_BUILD_DIR=jmeter
 JMETER_PLUGINS_BASE_URL=https://jmeter-plugins.org/files/packages/
 JMETER_PLUGINS=("websocket-samplers-1.2.10.zip" "jpgc-casutg-2.10.zip" "bzm-random-csv-0.8.zip" "jpgc-dummy-0.4.zip" "jpgc-prmctl-0.4.zip" "jpgc-wsc-0.7.zip")
 
-
-
 # Variables from CSV File v0.1
 # https://jmeter-plugins.org/files/packages/jpgc-csvars-0.1.zip
 

--- a/parameters.sh
+++ b/parameters.sh
@@ -9,6 +9,15 @@ JMETER_DIR=apache-jmeter-${JMETER_VERSION}
 # The name of the jmeter dir in the actual build of the app
 JMETER_BUILD_DIR=jmeter
 
+# jmeter plugins setup
+JMETER_PLUGINS_BASE_URL=https://jmeter-plugins.org/files/packages/
+JMETER_PLUGINS=("websocket-samplers-1.2.10.zip" "jpgc-casutg-2.10.zip" "bzm-random-csv-0.8.zip" "jpgc-dummy-0.4.zip" "jpgc-prmctl-0.4.zip" "jpgc-wsc-0.7.zip")
+
+
+
+# Variables from CSV File v0.1
+# https://jmeter-plugins.org/files/packages/jpgc-csvars-0.1.zip
+
 # java setup
 # Using the Bellsoft Liberca Open JRE, latest releases available at: https://bell-sw.com/pages/downloads/
 JAVA_VERSION="8u442+7"

--- a/utils/aws_configure_s3_creds.sh
+++ b/utils/aws_configure_s3_creds.sh
@@ -18,7 +18,7 @@ else
 fi
 
 # Configure the AWS CLI to use the S3 credentials from VCAP_SERVICES.
-echo "Running 'aws configure list' to set S3 service instance credentials"
+echo "Running 'aws configure set' to set S3 service instance credentials"
 AWS_ACCESS_KEY_ID="$(echo $VCAP_SERVICES | jq -r '.["csb-aws-s3-bucket"][0].credentials.access_key_id')"
 AWS_SECRET_ACCESS_KEY="$(echo $VCAP_SERVICES | jq -r '.["csb-aws-s3-bucket"][0].credentials.secret_access_key')"
 AWS_DEFAULT_REGION="$(echo $VCAP_SERVICES | jq -r '.["csb-aws-s3-bucket"][0].credentials.region')"


### PR DESCRIPTION
JMeter buildpacks will now download the following plugins:
- WebsocketSamplers v1.2.10 - https://jmeter-plugins.org/files/packages/websocket-samplers-1.2.10.zip
- Custom Thread Groups v2.10 - https://jmeter-plugins.org/files/packages/jpgc-casutg-2.10.zip
- Random CSV Data Set v0.8 - https://jmeter-plugins.org/files/packages/bzm-random-csv-0.8.zip
- Dummy Sampler v0.4 - https://jmeter-plugins.org/files/packages/jpgc-dummy-0.4.zip
- Parameterized Controller  Set Variables Action v0.4 - https://jmeter-plugins.org/files/packages/jpgc-prmctl-0.4.zip
- Weighted Switch Controller v0.7 - https://jmeter-plugins.org/files/packages/jpgc-wsc-0.7.zip

One key plugin that it does not install is the custom InfluxDB writer plugin we normally use at IR. This can be addressed later.